### PR TITLE
Replace redundant `observe` with `through`

### DIFF
--- a/prox-fs2-3/src/main/scala/io/github/vigoo/prox/ProxFS2.scala
+++ b/prox-fs2-3/src/main/scala/io/github/vigoo/prox/ProxFS2.scala
@@ -82,7 +82,7 @@ trait ProxFS2[F[_]] extends Prox {
 
   protected override final def drainToJavaOutputStream(stream: ProxStream[Byte], output: io.OutputStream, flushChunks: Boolean): ProxIO[Unit] =
     stream
-      .observe(
+      .through(
         if (flushChunks) writeAndFlushOutputStream(output)(_).drain
         else fs2.io.writeOutputStream(
           effect(output, UnknownProxError.apply),

--- a/prox-fs2/src/main/scala/io/github/vigoo/prox/ProxFS2.scala
+++ b/prox-fs2/src/main/scala/io/github/vigoo/prox/ProxFS2.scala
@@ -85,7 +85,7 @@ trait ProxFS2[F[_]] extends Prox {
 
   protected override final def drainToJavaOutputStream(stream: ProxStream[Byte], output: io.OutputStream, flushChunks: Boolean): ProxIO[Unit] =
     stream
-      .observe(
+      .through(
         if (flushChunks) writeAndFlushOutputStream(output)
         else fs2.io.writeOutputStream(
           effect(output, UnknownProxError.apply),


### PR DESCRIPTION
For some reason, using `observe` could cause some "stream already closed" issues when attaching input to a process (e.g. `nix eval '(import /dev/stdin)'`).