### PR TITLE
Fix cancellation in fs2 3

### DIFF
--- a/prox-fs2-3/src/main/scala/io/github/vigoo/prox/ProxFS2.scala
+++ b/prox-fs2-3/src/main/scala/io/github/vigoo/prox/ProxFS2.scala
@@ -34,7 +34,7 @@ trait ProxFS2[F[_]] extends Prox {
     }
 
   protected override final def blockingEffect[A](f: => A, wrapError: Throwable => ProxError): ProxIO[A] =
-    Sync[F].adaptError(Sync[F].blocking(f)) {
+    Sync[F].adaptError(Sync[F].interruptibleMany(f)) {
       case failure: Throwable => wrapError(failure).toThrowable
     }
 

--- a/prox-fs2-3/src/test/scala/io/github/vigoo/prox/tests/fs2/ProcessSpecs.scala
+++ b/prox-fs2-3/src/test/scala/io/github/vigoo/prox/tests/fs2/ProcessSpecs.scala
@@ -370,7 +370,18 @@ object ProcessSpecs extends DefaultRunnableSpec with ProxSpecHelpers {
           implicit val processRunner: ProcessRunner[JVMProcessInfo] = new JVMProcessRunner
 
           val process = Process("perl", List("-e", """$SIG{TERM} = sub { exit 1 }; sleep 30; exit 0"""))
-          val program = process.start().use { fiber => fiber.cancel }
+          val program = process.start().use { fiber => ZIO(Thread.sleep(250)).flatMap(_ => fiber.cancel) }
+
+          assertM(program)(equalTo(()))
+        } @@ TestAspect.timeout(5.seconds),
+
+        proxTest("can be terminated by releasing the resource") { prox =>
+          import prox._
+
+          implicit val processRunner: ProcessRunner[JVMProcessInfo] = new JVMProcessRunner
+
+          val process = Process("perl", List("-e", """$SIG{TERM} = sub { exit 1 }; sleep 30; exit 0"""))
+          val program = process.start().use { _ => ZIO(Thread.sleep(250)) }
 
           assertM(program)(equalTo(()))
         } @@ TestAspect.timeout(5.seconds),


### PR DESCRIPTION
This fixes #409 for fs2-3. The fix is trivial in this case because CE3 provides `interruptibleMany`. At the moment I don't know how to fix it for other variants of the library.

I also reproduced the issue using an existing test (it used to pass because cancel was called fast, before the uninterruptible effect started executing) and added a second similar test that checks specifically terminating the sub-process by releasing the Resource.